### PR TITLE
Add useBackdropFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.4]
+*  Adds `useBackdropFilter` property to set whether to use backdrop filter or not on background (particularly useful if you're having performance issues on lower end devices).
+
 ## [0.0.3]
 *  fix description and formatting
 

--- a/lib/highlighter_coachmark.dart
+++ b/lib/highlighter_coachmark.dart
@@ -44,13 +44,21 @@ import 'dart:ui' as ui;
 ///      });
 /// ```
 class CoachMark {
-  CoachMark({this.bgColor = const Color(0xB2212121)});
+  CoachMark({
+    this.bgColor = const Color(0xB2212121),
+    this.useBackdropFilter = true,
+  });
+
 
   /// Global key to get an access for CoachMark's State
   GlobalKey<_HighlighterCoachMarkState> globalKey;
 
   /// Background color
   Color bgColor;
+
+  /// Defines if CoachMark should apply a backdrop filter to blurry the background.
+  /// Defaults to `true`.
+  bool useBackdropFilter;
 
   /// State visibility of CoachMark
   bool _isVisible = false;
@@ -111,6 +119,7 @@ class CoachMark {
                 markShape: markShape,
                 doClose: close,
                 children: children,
+                useBackdrop: useBackdropFilter,
               ),
         );
 
@@ -146,6 +155,7 @@ class _HighlighterCoachMarkWidget extends StatefulWidget {
     @required this.children,
     @required this.doClose,
     @required this.bgColor,
+    this.useBackdrop = true,
   }) : super(key: key);
 
   final Rect markRect;
@@ -153,6 +163,7 @@ class _HighlighterCoachMarkWidget extends StatefulWidget {
   final List<Widget> children;
   final VoidCallback doClose;
   final Color bgColor;
+  final bool useBackdrop;
 
   @override
   _HighlighterCoachMarkState createState() => new _HighlighterCoachMarkState();
@@ -215,17 +226,16 @@ class _HighlighterCoachMarkState extends State<_HighlighterCoachMarkWidget>
         builder: (BuildContext context, Widget child) {
           return Stack(
             children: <Widget>[
-              ClipPath(
-                clipper: clipper,
-                child: BackdropFilter(
-                  filter: ui.ImageFilter.blur(
-                      sigmaX: _blurAnimation.value,
-                      sigmaY: _blurAnimation.value),
-                  child: Container(
-                    color: Colors.transparent,
+              if (widget.useBackdrop)
+                ClipPath(
+                  clipper: clipper,
+                  child: BackdropFilter(
+                    filter: ui.ImageFilter.blur(sigmaX: _blurAnimation.value, sigmaY: _blurAnimation.value),
+                    child: Container(
+                      color: Colors.transparent,
+                    ),
                   ),
                 ),
-              ),
               _CoachMarkLayer(
                 behavior: HitTestBehavior.translucent,
                 onPointerDown: _onPointer,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: highlighter_coachmark
 description: Coach Mark shows provided tips or inctructions in overlay by blurring background and highlighting target element.
-version: 0.0.3
+version: 0.0.4
 author:  Marina Kuznetsova <marica.tim@gmail.com>
 homepage: https://github.com/marica27/highlighter-coachmark
 maintainer: Marina Kuznetsova (@marica27)
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Using BackdropFilter has a big impact in performance specially when using multiple `CoachMarks` on lower end devices. It has a nice effect, however, in some cases using just an alpha color on background is enough and may result in a better experience.

Hence, this PR aims to add the `useBackdropFilter` property which defaults to `true` but lets developers remove the `BackdropFilter` if they want to.

Thank you!